### PR TITLE
hs/fibonacci: Use Int instead of Integer

### DIFF
--- a/langs/haskell/impls/fibonacci-nr/0.hs
+++ b/langs/haskell/impls/fibonacci-nr/0.hs
@@ -1,6 +1,7 @@
 module Main where
 import System.Environment
 
+fib :: Int -> Int
 fib 0 = 1
 fib 1 = 1
 fib n = fib(n-1) + fib(n-2)


### PR DESCRIPTION
fib was missing a type annotation, which caused its type to be defaulted
to Integer (i.e. libgmp unbounded integers) instead of machine ints.